### PR TITLE
Add run notebook workflow

### DIFF
--- a/.github/workflows/run-linux-cuda.yml
+++ b/.github/workflows/run-linux-cuda.yml
@@ -1,0 +1,36 @@
+name: run-linux-cuda
+
+on:
+  workflow_dispatch:
+    inputs:
+      notebook-path:
+        description: Path to the notebook to run
+        required: true
+        type: string
+
+jobs:
+  docker:
+    runs-on: [self-hosted, Linux, X64, CUDA]
+
+    container:
+      image: martinkim0/scvi-tools:ubuntu-latest-mamba-latest-python-3.11-cuda-11
+      options: --user root --gpus all
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          pip install -U scvi-tools[tutorials]
+
+      - name: Install nbconvert
+        run: |
+          pip install -U nbconvert
+
+      - name: Run notebook
+        run: |
+          python -m jupyter nbconvert --execute --inplace ${{ inputs.notebook-path }}
+
+      - name: Submit pull request with changes
+        uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
## Formatting

- [ ] My tutorial has only one top-level (`#`) header

## Reproducibility

- [ ] My tutorial works on Google Colab
- [ ] My tutorial sets `scvi.settings.seed = 0` at the beginning of the notebook
- [ ] My tutorial has been run and includes outputs (e.g. plots, tables)

## Other

- [ ] Counts and normalized data should co-exist in the datasets, see the [API overview](https://docs.scvi-tools.org/en/stable/tutorials/notebooks/api_overview.html) for an example
- [ ] For scRNA-seq data, normalization should be counts per median library size and then log1p transformed -- if not, a reason should be given
