### PR TITLE
Explicitly add notebook paths to workflow

### DIFF
--- a/.github/workflows/run_linux_cuda.yml
+++ b/.github/workflows/run_linux_cuda.yml
@@ -6,7 +6,40 @@ on:
       notebook-path:
         description: Path to the notebook to run
         required: true
-        type: string
+        type: choice
+        options: # not including R tutorials currently
+          - atac/PeakVI.ipynb
+          - atac/scbasset_batch.ipynb
+          - atac/scbasset.ipynb
+          - dev/data_tutorial.ipynb
+          - dev/model_user_guide.ipynb
+          - dev/module_user_guide.ipynb
+          - hub/minification.ipynb
+          - hub/scvi_hub_intro_and_download.ipynb
+          - hub/scvi_hub_upload_and_large_files.ipynb
+          - multimodal/cite_scrna_integration_w_totalVI.ipynb
+          - multimodal/MultiVI_tutorial.ipynb
+          - multimodal/totalVI_reference_mapping.ipynb
+          - multimodal/totalVI.ipynb
+          - quick_start/api_overview.ipynb
+          - quick_start/data_loading.ipynb
+          - scrna/amortized_lda.ipynb
+          - scrna/AutoZI_tutorial.ipynb
+          - scrna/cellassign_tutorial.ipynb
+          - scrna/harmonization.ipynb
+          - scrna/linear_decoder.ipynb
+          - scrna/query_hlca_knn.ipynb
+          - scrna/scarches_scvi_tools.ipynb
+          - scrna/scVI_DE_worm.ipynb
+          - scrna/seed_labeling.ipynb
+          - scrna/tabula_muris.ipynb
+          - spatial/cell2location_lymph_node_spatial_tutorial.ipynb
+          - spatial/DestVI_tutorial.ipynb
+          - spatial/gimvi_tutorial.ipynb
+          - spatial/stereoscope_heart_LV_tutorial.ipynb
+          - spatial/tangram_scvi_tools.ipynb
+          - tuning/autotune_new_model.ipynb
+          - tuning/autotune_scvi.ipynb
       python-version:
         description: Python version
         required: true


### PR DESCRIPTION
## Formatting

- [ ] My tutorial has only one top-level (`#`) header

## Reproducibility

- [ ] My tutorial works on Google Colab
- [ ] My tutorial sets `scvi.settings.seed = 0` at the beginning of the notebook
- [ ] My tutorial has been run and includes outputs (e.g. plots, tables)

## Other

- [ ] Counts and normalized data should co-exist in the datasets, see the [API overview](https://docs.scvi-tools.org/en/stable/tutorials/notebooks/api_overview.html) for an example
- [ ] For scRNA-seq data, normalization should be counts per median library size and then log1p transformed -- if not, a reason should be given
