### PR TITLE
Fix autotune tutorial

### DIFF
--- a/tuning/autotune_new_model.ipynb
+++ b/tuning/autotune_new_model.ipynb
@@ -73,7 +73,8 @@
                 "from flax.core import freeze\n",
                 "from ray import tune\n",
                 "from scvi._decorators import classproperty\n",
-                "from scvi.autotune import Tunable, TunableMixin"
+                "from scvi._types import Tunable, TunableMixin\n",
+                "from scvi.autotune import ModelTuner"
             ]
         },
         {
@@ -82,10 +83,17 @@
             "metadata": {},
             "outputs": [
                 {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "Seed set to 0\n"
+                    ]
+                },
+                {
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "Last run with scvi-tools version: 1.0.3\n"
+                        "Last run with scvi-tools version: 1.1.0\n"
                     ]
                 }
             ],
@@ -229,7 +237,7 @@
                     "name": "stderr",
                     "output_type": "stream",
                     "text": [
-                        "/home/martin/dev/scvi-tools/scvi/autotune/_manager.py:60: UserWarning: No default search space available for LassoTunable.\n",
+                        "/home/martinkim/dev/scvi-tools/scvi/autotune/_manager.py:57: UserWarning: No default search space available for LassoTunable.\n",
                         "  self._defaults = self._get_defaults(self._model_cls)\n"
                     ]
                 },
@@ -317,7 +325,7 @@
                 }
             ],
             "source": [
-                "tuner = scvi.autotune.ModelTuner(LassoTunable)\n",
+                "tuner = ModelTuner(LassoTunable)\n",
                 "tuner.info()"
             ]
         },
@@ -538,7 +546,7 @@
                     "name": "stderr",
                     "output_type": "stream",
                     "text": [
-                        "/home/martin/dev/scvi-tools/scvi/autotune/_manager.py:60: UserWarning: No default search space available for LassoModel.\n",
+                        "/home/martinkim/dev/scvi-tools/scvi/autotune/_manager.py:57: UserWarning: No default search space available for LassoModel.\n",
                         "  self._defaults = self._get_defaults(self._model_cls)\n"
                     ]
                 },
@@ -654,7 +662,7 @@
             "name": "python",
             "nbconvert_exporter": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.11.4"
+            "version": "3.11.6"
         },
         "orig_nbformat": 4,
         "vscode": {


### PR DESCRIPTION
## Formatting

- [ ] My tutorial has only one top-level (`#`) header

## Reproducibility

- [ ] My tutorial works on Google Colab
- [ ] My tutorial sets `scvi.settings.seed = 0` at the beginning of the notebook
- [ ] My tutorial has been run and includes outputs (e.g. plots, tables)

## Other

- [ ] Counts and normalized data should co-exist in the datasets, see the [API overview](https://docs.scvi-tools.org/en/stable/tutorials/notebooks/api_overview.html) for an example
- [ ] For scRNA-seq data, normalization should be counts per median library size and then log1p transformed -- if not, a reason should be given
