### PR TITLE
Fix stereoscope tutorial

### DIFF
--- a/spatial/stereoscope_heart_LV_tutorial.ipynb
+++ b/spatial/stereoscope_heart_LV_tutorial.ipynb
@@ -488,15 +488,12 @@
    },
    "outputs": [],
    "source": [
-    "train = True\n",
-    "if train:\n",
-    "    sc_model = RNAStereoscope(sc_adata)\n",
-    "    sc_model.train(max_epochs=100)\n",
-    "    sc_model.history[\"elbo_train\"][10:].plot()\n",
-    "    sc_model.save(\"scmodel\", overwrite=True)\n",
-    "else:\n",
-    "    sc_model = RNAStereoscope.load(\"scmodel\", adata=sc_adata)\n",
-    "    print(\"Loaded RNA model from file!\")"
+    "sc_model_path = os.path.join(save_dir.name, \"sc_model\")\n",
+    "\n",
+    "sc_model = RNAStereoscope(sc_adata)\n",
+    "sc_model.train(max_epochs=100)\n",
+    "sc_model.history[\"elbo_train\"][10:].plot()\n",
+    "sc_model.save(sc_model_path, overwrite=True)"
    ]
   },
   {
@@ -546,15 +543,12 @@
    },
    "outputs": [],
    "source": [
-    "train = True\n",
-    "if train:\n",
-    "    spatial_model = SpatialStereoscope.from_rna_model(st_adata, sc_model)\n",
-    "    spatial_model.train(max_epochs=2000)\n",
-    "    spatial_model.history[\"elbo_train\"][10:].plot()\n",
-    "    spatial_model.save(\"stmodel\", overwrite=True)\n",
-    "else:\n",
-    "    spatial_model = SpatialStereoscope.load(\"stmodel\", adata=st_adata)\n",
-    "    print(\"Loaded Spatial model from file!\")"
+    "spatial_model_path = os.path.join(save_dir.name, \"spatial_model\")\n",
+    "\n",
+    "spatial_model = SpatialStereoscope.from_rna_model(st_adata, sc_model)\n",
+    "spatial_model.train(max_epochs=2000)\n",
+    "spatial_model.history[\"elbo_train\"][10:].plot()\n",
+    "spatial_model.save(spatial_model_path, overwrite=True)"
    ]
   },
   {
@@ -619,15 +613,6 @@
     "    color_map=\"inferno\",\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "WfEk_qy0f2tA"
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Formatting

- [ ] My tutorial has only one top-level (`#`) header

## Reproducibility

- [ ] My tutorial works on Google Colab
- [ ] My tutorial sets `scvi.settings.seed = 0` at the beginning of the notebook
- [ ] My tutorial has been run and includes outputs (e.g. plots, tables)

## Other

- [ ] Counts and normalized data should co-exist in the datasets, see the [API overview](https://docs.scvi-tools.org/en/stable/tutorials/notebooks/api_overview.html) for an example
- [ ] For scRNA-seq data, normalization should be counts per median library size and then log1p transformed -- if not, a reason should be given
