### PR TITLE
Fix contrastivevi tutorial

### DIFF
--- a/scrna/contrastiveVI_tutorial.ipynb
+++ b/scrna/contrastiveVI_tutorial.ipynb
@@ -59,6 +59,7 @@
     "import tempfile\n",
     "\n",
     "import numpy as np\n",
+    "import requests\n",
     "import scanpy as sc\n",
     "import scvi\n",
     "import torch"
@@ -163,6 +164,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_cell_cycle_genes() -> list:\n",
+    "    # Canonical list of cell cycle genes\n",
+    "    url = \"https://raw.githubusercontent.com/scverse/scanpy_usage/master/180209_cell_cycle/data/regev_lab_cell_cycle_genes.txt\"\n",
+    "    cell_cycle_genes = requests.get(url).text.split(\"\\n\")[:-1]\n",
+    "    return cell_cycle_genes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -172,10 +186,7 @@
    },
    "outputs": [],
    "source": [
-    "# Canonical list of cell cycle genes\n",
-    "!wget https://raw.githubusercontent.com/scverse/scanpy_usage/master/180209_cell_cycle/data/regev_lab_cell_cycle_genes.txt\n",
-    "\n",
-    "cell_cycle_genes = [x.strip() for x in open(\"./regev_lab_cell_cycle_genes.txt\")]\n",
+    "cell_cycle_genes = get_cell_cycle_genes()\n",
     "\n",
     "s_genes = cell_cycle_genes[:43]\n",
     "g2m_genes = cell_cycle_genes[43:]\n",


### PR DESCRIPTION
## Formatting

- [ ] My tutorial has only one top-level (`#`) header

## Reproducibility

- [ ] My tutorial works on Google Colab
- [ ] My tutorial sets `scvi.settings.seed = 0` at the beginning of the notebook
- [ ] My tutorial has been run and includes outputs (e.g. plots, tables)

## Other

- [ ] Counts and normalized data should co-exist in the datasets, see the [API overview](https://docs.scvi-tools.org/en/stable/tutorials/notebooks/api_overview.html) for an example
- [ ] For scRNA-seq data, normalization should be counts per median library size and then log1p transformed -- if not, a reason should be given
