### PR TITLE
Increase workflow timeout minutes

### DIFF
--- a/.github/workflows/run_linux_cuda.yml
+++ b/.github/workflows/run_linux_cuda.yml
@@ -75,6 +75,8 @@ jobs:
       image: martinkim0/scvi-tools:py${{ inputs.python-version }}-cu${{ inputs.cuda-version }}-devel-${{ inputs.scvi-tools-version }}
       options: --user root --gpus all
 
+    timeout-minutes: 600 # lenient timeout for scbasset tutorial
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/run_linux_cuda_branch.yml
+++ b/.github/workflows/run_linux_cuda_branch.yml
@@ -75,6 +75,8 @@ jobs:
       image: martinkim0/scvi-tools:py${{ inputs.python-version }}-cu${{ inputs.cuda-version }}-tutorials-${{ inputs.branch-name}}
       options: --user root --gpus all
 
+    timeout-minutes: 600 # lenient timeout for scbasset tutorial
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Formatting

- [ ] My tutorial has only one top-level (`#`) header

## Reproducibility

- [ ] My tutorial works on Google Colab
- [ ] My tutorial sets `scvi.settings.seed = 0` at the beginning of the notebook
- [ ] My tutorial has been run and includes outputs (e.g. plots, tables)

## Other

- [ ] Counts and normalized data should co-exist in the datasets, see the [API overview](https://docs.scvi-tools.org/en/stable/tutorials/notebooks/api_overview.html) for an example
- [ ] For scRNA-seq data, normalization should be counts per median library size and then log1p transformed -- if not, a reason should be given
