### PR TITLE
Use logging_dir for autotune

### DIFF
--- a/tuning/autotune_scvi.ipynb
+++ b/tuning/autotune_scvi.ipynb
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-12-07T19:29:24.822153Z",
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-12-07T19:29:24.826130Z",
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-12-07T19:29:28.346115Z",
@@ -107,22 +107,7 @@
      "shell.execute_reply": "2023-12-07T19:29:28.349520Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Seed set to 0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Last run with scvi-tools version: 1.1.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "scvi.settings.seed = 0\n",
     "print(\"Last run with scvi-tools version:\", scvi.__version__)"
@@ -139,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-12-07T19:29:28.368700Z",
@@ -154,6 +139,7 @@
     "sns.set_theme()\n",
     "torch.set_float32_matmul_precision(\"high\")\n",
     "save_dir = tempfile.TemporaryDirectory()\n",
+    "scvi.settings.logging_dir = save_dir.name\n",
     "\n",
     "%config InlineBackend.print_figure_kwargs={\"facecolor\": \"w\"}\n",
     "%config InlineBackend.figure_format=\"retina\""
@@ -169,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-12-07T19:29:28.379095Z",
@@ -178,29 +164,7 @@
      "shell.execute_reply": "2023-12-07T19:29:30.397616Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[34mINFO    \u001b[0m Downloading file at \u001b[35m/tmp/tmpafthtjrs/\u001b[0m\u001b[95mhca_subsampled_20k.h5ad\u001b[0m                                              \n",
-      "Downloading...: 100%|██████████| 65714/65714.0 [00:00<00:00, 97942.71it/s] \n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "AnnData object with n_obs × n_vars = 18641 × 26662\n",
-       "    obs: 'NRP', 'age_group', 'cell_source', 'cell_type', 'donor', 'gender', 'n_counts', 'n_genes', 'percent_mito', 'percent_ribo', 'region', 'sample', 'scrublet_score', 'source', 'type', 'version', 'cell_states', 'Used'\n",
-       "    var: 'gene_ids-Harvard-Nuclei', 'feature_types-Harvard-Nuclei', 'gene_ids-Sanger-Nuclei', 'feature_types-Sanger-Nuclei', 'gene_ids-Sanger-Cells', 'feature_types-Sanger-Cells', 'gene_ids-Sanger-CD45', 'feature_types-Sanger-CD45', 'n_counts'\n",
-       "    uns: 'cell_type_colors'"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "adata = scvi.data.heart_cell_atlas_subsampled(save_path=save_dir.name)\n",
     "adata"
@@ -216,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-12-07T19:29:30.399694Z",
@@ -225,21 +189,7 @@
      "shell.execute_reply": "2023-12-07T19:29:31.758275Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "AnnData object with n_obs × n_vars = 18641 × 2000\n",
-       "    obs: 'NRP', 'age_group', 'cell_source', 'cell_type', 'donor', 'gender', 'n_counts', 'n_genes', 'percent_mito', 'percent_ribo', 'region', 'sample', 'scrublet_score', 'source', 'type', 'version', 'cell_states', 'Used'\n",
-       "    var: 'gene_ids-Harvard-Nuclei', 'feature_types-Harvard-Nuclei', 'gene_ids-Sanger-Nuclei', 'feature_types-Sanger-Nuclei', 'gene_ids-Sanger-Cells', 'feature_types-Sanger-Cells', 'gene_ids-Sanger-CD45', 'feature_types-Sanger-CD45', 'n_counts', 'highly_variable', 'highly_variable_rank', 'means', 'variances', 'variances_norm'\n",
-       "    uns: 'cell_type_colors', 'hvg'"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sc.pp.highly_variable_genes(adata, n_top_genes=2000, flavor=\"seurat_v3\", subset=True)\n",
     "adata"
@@ -263,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-12-07T19:29:31.760288Z",
@@ -272,20 +222,7 @@
      "shell.execute_reply": "2023-12-07T19:29:31.916065Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<frozen abc>:119: FutureWarning: SparseDataset is deprecated and will be removed in late 2024. It has been replaced by the public classes CSRDataset and CSCDataset.\n",
-      "\n",
-      "For instance checks, use `isinstance(X, (anndata.experimental.CSRDataset, anndata.experimental.CSCDataset))` instead.\n",
-      "\n",
-      "For creation, use `anndata.experimental.sparse_dataset(X)` instead.\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "model_cls = scvi.model.SCVI\n",
     "model_cls.setup_anndata(adata)"
@@ -301,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-12-07T19:29:31.918113Z",
@@ -329,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-12-07T19:29:32.071461Z",
@@ -338,144 +275,7 @@
      "shell.execute_reply": "2023-12-07T19:29:32.084124Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">ModelTuner registry for SCVI\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "ModelTuner registry for SCVI\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-style: italic\">                  Tunable hyperparameters                  </span>\n",
-       "┏━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓\n",
-       "┃<span style=\"font-weight: bold\">      Hyperparameter      </span>┃<span style=\"font-weight: bold\"> Default value </span>┃<span style=\"font-weight: bold\">    Source    </span>┃\n",
-       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">         n_hidden         </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">      128      </span>│<span style=\"color: #008000; text-decoration-color: #008000\">     VAE      </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">         n_latent         </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">      10       </span>│<span style=\"color: #008000; text-decoration-color: #008000\">     VAE      </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">         n_layers         </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">       1       </span>│<span style=\"color: #008000; text-decoration-color: #008000\">     VAE      </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">       dropout_rate       </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">      0.1      </span>│<span style=\"color: #008000; text-decoration-color: #008000\">     VAE      </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">        dispersion        </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">     gene      </span>│<span style=\"color: #008000; text-decoration-color: #008000\">     VAE      </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">     log_variational      </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">     True      </span>│<span style=\"color: #008000; text-decoration-color: #008000\">     VAE      </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">     gene_likelihood      </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">     zinb      </span>│<span style=\"color: #008000; text-decoration-color: #008000\">     VAE      </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">   latent_distribution    </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">    normal     </span>│<span style=\"color: #008000; text-decoration-color: #008000\">     VAE      </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">    encode_covariates     </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">     False     </span>│<span style=\"color: #008000; text-decoration-color: #008000\">     VAE      </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\"> deeply_inject_covariates </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">     True      </span>│<span style=\"color: #008000; text-decoration-color: #008000\">     VAE      </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">      use_batch_norm      </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">     both      </span>│<span style=\"color: #008000; text-decoration-color: #008000\">     VAE      </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">      use_layer_norm      </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">     none      </span>│<span style=\"color: #008000; text-decoration-color: #008000\">     VAE      </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">  use_observed_lib_size   </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">     True      </span>│<span style=\"color: #008000; text-decoration-color: #008000\">     VAE      </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">      var_activation      </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">     None      </span>│<span style=\"color: #008000; text-decoration-color: #008000\">     VAE      </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">        optimizer         </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">     Adam      </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> TrainingPlan </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">            lr            </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">     0.001     </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> TrainingPlan </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">       weight_decay       </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">     1e-06     </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> TrainingPlan </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">           eps            </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">     0.01      </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> TrainingPlan </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">    n_steps_kl_warmup     </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">     None      </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> TrainingPlan </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">    n_epochs_kl_warmup    </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">      400      </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> TrainingPlan </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">   reduce_lr_on_plateau   </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">     False     </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> TrainingPlan </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">        lr_factor         </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">      0.6      </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> TrainingPlan </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">       lr_patience        </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">      30       </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> TrainingPlan </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">       lr_threshold       </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">      0.0      </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> TrainingPlan </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">          lr_min          </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">       0       </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> TrainingPlan </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">      max_kl_weight       </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">      1.0      </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> TrainingPlan </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">      min_kl_weight       </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">      0.0      </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> TrainingPlan </span>│\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">        batch_size        </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">      128      </span>│<span style=\"color: #008000; text-decoration-color: #008000\">     SCVI     </span>│\n",
-       "└──────────────────────────┴───────────────┴──────────────┘\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[3m                  Tunable hyperparameters                  \u001b[0m\n",
-       "┏━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓\n",
-       "┃\u001b[1m \u001b[0m\u001b[1m     Hyperparameter     \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mDefault value\u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m   Source   \u001b[0m\u001b[1m \u001b[0m┃\n",
-       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m        n_hidden        \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m     128     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32m    VAE     \u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m        n_latent        \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m     10      \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32m    VAE     \u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m        n_layers        \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m      1      \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32m    VAE     \u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m      dropout_rate      \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m     0.1     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32m    VAE     \u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m       dispersion       \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m    gene     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32m    VAE     \u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m    log_variational     \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m    True     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32m    VAE     \u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m    gene_likelihood     \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m    zinb     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32m    VAE     \u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m  latent_distribution   \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m   normal    \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32m    VAE     \u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m   encode_covariates    \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m    False    \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32m    VAE     \u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33mdeeply_inject_covariates\u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m    True     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32m    VAE     \u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m     use_batch_norm     \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m    both     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32m    VAE     \u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m     use_layer_norm     \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m    none     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32m    VAE     \u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m use_observed_lib_size  \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m    True     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32m    VAE     \u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m     var_activation     \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m    None     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32m    VAE     \u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m       optimizer        \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m    Adam     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mTrainingPlan\u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m           lr           \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m    0.001    \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mTrainingPlan\u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m      weight_decay      \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m    1e-06    \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mTrainingPlan\u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m          eps           \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m    0.01     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mTrainingPlan\u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m   n_steps_kl_warmup    \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m    None     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mTrainingPlan\u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m   n_epochs_kl_warmup   \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m     400     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mTrainingPlan\u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m  reduce_lr_on_plateau  \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m    False    \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mTrainingPlan\u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m       lr_factor        \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m     0.6     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mTrainingPlan\u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m      lr_patience       \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m     30      \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mTrainingPlan\u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m      lr_threshold      \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m     0.0     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mTrainingPlan\u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m         lr_min         \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m      0      \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mTrainingPlan\u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m     max_kl_weight      \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m     1.0     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mTrainingPlan\u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m     min_kl_weight      \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m     0.0     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mTrainingPlan\u001b[0m\u001b[32m \u001b[0m│\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m       batch_size       \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m     128     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32m    SCVI    \u001b[0m\u001b[32m \u001b[0m│\n",
-       "└──────────────────────────┴───────────────┴──────────────┘\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-style: italic\">       Available metrics        </span>\n",
-       "┏━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓\n",
-       "┃<span style=\"font-weight: bold\">     Metric      </span>┃<span style=\"font-weight: bold\">    Mode    </span>┃\n",
-       "┡━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\"> validation_loss </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">    min     </span>│\n",
-       "└─────────────────┴────────────┘\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[3m       Available metrics        \u001b[0m\n",
-       "┏━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓\n",
-       "┃\u001b[1m \u001b[0m\u001b[1m    Metric     \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m   Mode   \u001b[0m\u001b[1m \u001b[0m┃\n",
-       "┡━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33mvalidation_loss\u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m   min    \u001b[0m\u001b[38;5;128m \u001b[0m│\n",
-       "└─────────────────┴────────────┘\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-style: italic\">                         Default search space                         </span>\n",
-       "┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓\n",
-       "┃<span style=\"font-weight: bold\"> Hyperparameter </span>┃<span style=\"font-weight: bold\"> Sample function </span>┃<span style=\"font-weight: bold\">  Arguments  </span>┃<span style=\"font-weight: bold\"> Keyword arguments </span>┃\n",
-       "┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩\n",
-       "│<span style=\"color: #0087ff; text-decoration-color: #0087ff\">    n_hidden    </span>│<span style=\"color: #af00d7; text-decoration-color: #af00d7\">     choice      </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> [[64, 128]] </span>│<span style=\"color: #ff8700; text-decoration-color: #ff8700\">        {}         </span>│\n",
-       "└────────────────┴─────────────────┴─────────────┴───────────────────┘\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[3m                         Default search space                         \u001b[0m\n",
-       "┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓\n",
-       "┃\u001b[1m \u001b[0m\u001b[1mHyperparameter\u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mSample function\u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m Arguments \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mKeyword arguments\u001b[0m\u001b[1m \u001b[0m┃\n",
-       "┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩\n",
-       "│\u001b[38;5;33m \u001b[0m\u001b[38;5;33m   n_hidden   \u001b[0m\u001b[38;5;33m \u001b[0m│\u001b[38;5;128m \u001b[0m\u001b[38;5;128m    choice     \u001b[0m\u001b[38;5;128m \u001b[0m│\u001b[32m \u001b[0m\u001b[32m[[64, 128]]\u001b[0m\u001b[32m \u001b[0m│\u001b[38;5;208m \u001b[0m\u001b[38;5;208m       {}        \u001b[0m\u001b[38;5;208m \u001b[0m│\n",
-       "└────────────────┴─────────────────┴─────────────┴───────────────────┘\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "scvi_tuner.info()"
    ]
@@ -498,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-12-07T19:29:32.085956Z",
@@ -551,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-12-07T19:29:32.089406Z",
@@ -560,93 +360,7 @@
      "shell.execute_reply": "2023-12-07T19:32:33.391108Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div class=\"tuneStatus\">\n",
-       "  <div style=\"display: flex;flex-direction: row\">\n",
-       "    <div style=\"display: flex;flex-direction: column;\">\n",
-       "      <h3>Tune Status</h3>\n",
-       "      <table>\n",
-       "<tbody>\n",
-       "<tr><td>Current time:</td><td>2023-12-07 19:32:33</td></tr>\n",
-       "<tr><td>Running for: </td><td>00:02:59.06        </td></tr>\n",
-       "<tr><td>Memory:      </td><td>9.6/125.7 GiB      </td></tr>\n",
-       "</tbody>\n",
-       "</table>\n",
-       "    </div>\n",
-       "    <div class=\"vDivider\"></div>\n",
-       "    <div class=\"systemInfo\">\n",
-       "      <h3>System Info</h3>\n",
-       "      Using AsyncHyperBand: num_stopped=5<br>Bracket: Iter 64.000: -456.2224578857422 | Iter 32.000: -457.0051574707031 | Iter 16.000: -460.7762145996094 | Iter 8.000: -468.9873046875 | Iter 4.000: -479.00633239746094 | Iter 2.000: -495.6261749267578 | Iter 1.000: -533.16845703125<br>Logical resource usage: 10.0/20 CPUs, 1.0/1 GPUs (0.0/1.0 accelerator_type:G)\n",
-       "    </div>\n",
-       "    \n",
-       "  </div>\n",
-       "  <div class=\"hDivider\"></div>\n",
-       "  <div class=\"trialStatus\">\n",
-       "    <h3>Trial Status</h3>\n",
-       "    <table>\n",
-       "<thead>\n",
-       "<tr><th>Trial name         </th><th>status    </th><th>loc              </th><th style=\"text-align: right;\">  n_hidden</th><th style=\"text-align: right;\">  n_layers</th><th style=\"text-align: right;\">         lr</th><th style=\"text-align: right;\">  validation_loss</th></tr>\n",
-       "</thead>\n",
-       "<tbody>\n",
-       "<tr><td>_trainable_43635405</td><td>TERMINATED</td><td>192.168.80.2:1032</td><td style=\"text-align: right;\">        64</td><td style=\"text-align: right;\">         2</td><td style=\"text-align: right;\">0.00169    </td><td style=\"text-align: right;\">          456.297</td></tr>\n",
-       "<tr><td>_trainable_b8c4083f</td><td>TERMINATED</td><td>192.168.80.2:1032</td><td style=\"text-align: right;\">       256</td><td style=\"text-align: right;\">         1</td><td style=\"text-align: right;\">0.000978826</td><td style=\"text-align: right;\">          457.779</td></tr>\n",
-       "<tr><td>_trainable_8b17d361</td><td>TERMINATED</td><td>192.168.80.2:1032</td><td style=\"text-align: right;\">       128</td><td style=\"text-align: right;\">         2</td><td style=\"text-align: right;\">0.0015655  </td><td style=\"text-align: right;\">          552.937</td></tr>\n",
-       "<tr><td>_trainable_8d3749eb</td><td>TERMINATED</td><td>192.168.80.2:1032</td><td style=\"text-align: right;\">       256</td><td style=\"text-align: right;\">         3</td><td style=\"text-align: right;\">0.00327036 </td><td style=\"text-align: right;\">          456.801</td></tr>\n",
-       "<tr><td>_trainable_ca2deba8</td><td>TERMINATED</td><td>192.168.80.2:1032</td><td style=\"text-align: right;\">       128</td><td style=\"text-align: right;\">         2</td><td style=\"text-align: right;\">0.0030879  </td><td style=\"text-align: right;\">          457.043</td></tr>\n",
-       "</tbody>\n",
-       "</table>\n",
-       "  </div>\n",
-       "</div>\n",
-       "<style>\n",
-       ".tuneStatus {\n",
-       "  color: var(--jp-ui-font-color1);\n",
-       "}\n",
-       ".tuneStatus .systemInfo {\n",
-       "  display: flex;\n",
-       "  flex-direction: column;\n",
-       "}\n",
-       ".tuneStatus td {\n",
-       "  white-space: nowrap;\n",
-       "}\n",
-       ".tuneStatus .trialStatus {\n",
-       "  display: flex;\n",
-       "  flex-direction: column;\n",
-       "}\n",
-       ".tuneStatus h3 {\n",
-       "  font-weight: bold;\n",
-       "}\n",
-       ".tuneStatus .hDivider {\n",
-       "  border-bottom-width: var(--jp-border-width);\n",
-       "  border-bottom-color: var(--jp-border-color0);\n",
-       "  border-bottom-style: solid;\n",
-       "}\n",
-       ".tuneStatus .vDivider {\n",
-       "  border-left-width: var(--jp-border-width);\n",
-       "  border-left-color: var(--jp-border-color0);\n",
-       "  border-left-style: solid;\n",
-       "  margin: 0.5em 1em 0.5em 1em;\n",
-       "}\n",
-       "</style>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-12-07 19:29:34,307\tINFO tune.py:645 -- [output] This uses the legacy output and progress reporter, as Jupyter notebooks are not supported by the new engine, yet. For more information, please see https://github.com/ray-project/ray/issues/36949\n",
-      "2023-12-07 19:32:33,383\tINFO tune.py:1143 -- Total run time: 179.08 seconds (179.06 seconds for the tuning loop).\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ray.init(log_to_driver=False)\n",
     "results = scvi_tuner.fit(\n",
@@ -661,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2023-12-07T19:32:33.393199Z",
@@ -670,16 +384,7 @@
      "shell.execute_reply": "2023-12-07T19:32:33.394995Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'n_hidden': 64, 'n_layers': 2}\n",
-      "{'plan_kwargs': {'lr': 0.0016900002795988184}}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(results.model_kwargs)\n",
     "print(results.train_kwargs)"
@@ -750,7 +455,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.7"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
## Formatting

- [ ] My tutorial has only one top-level (`#`) header

## Reproducibility

- [ ] My tutorial works on Google Colab
- [ ] My tutorial sets `scvi.settings.seed = 0` at the beginning of the notebook
- [ ] My tutorial has been run and includes outputs (e.g. plots, tables)

## Other

- [ ] Counts and normalized data should co-exist in the datasets, see the [API overview](https://docs.scvi-tools.org/en/stable/tutorials/notebooks/api_overview.html) for an example
- [ ] For scRNA-seq data, normalization should be counts per median library size and then log1p transformed -- if not, a reason should be given
