### PR TITLE
Update run_notebook.yaml

### DIFF
--- a/.github/workflows/run_notebook.yaml
+++ b/.github/workflows/run_notebook.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64, CUDA]
 
     container:
-      image: ghcr.io/scverse/scvi-tools:py3.11-cu12-${{ inputs.version }}-tutorials
+      image: ghcr.io/scverse/scvi-tools:py3.12-cu12-${{ inputs.version }}-tutorials
       options: --user root --gpus all
 
     timeout-minutes: 600 # lenient timeout for scbasset tutorial


### PR DESCRIPTION
## Formatting

- [ ] My tutorial has only one top-level (`#`) header

## Reproducibility

- [ ] My tutorial works on Google Colab
- [ ] My tutorial sets `scvi.settings.seed = 0` at the beginning of the notebook
- [ ] My tutorial has been run and includes outputs (e.g. plots, tables)

## Other

- [ ] Counts and normalized data should co-exist in the datasets, see the [API overview](https://docs.scvi-tools.org/en/stable/tutorials/notebooks/api_overview.html) for an example
- [ ] For scRNA-seq data, normalization should be counts per median library size and then log1p transformed -- if not, a reason should be given
