### PR TITLE
docs: Remove autotune hyperparameters info from tutorial

### DIFF
--- a/tuning/autotune_scvi.ipynb
+++ b/tuning/autotune_scvi.ipynb
@@ -351,11 +351,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`ModelTuner` will register all tunable hyperparameters in `SCVI` -- these can be viewed by calling `info()`. By default, this method will display three tables:\n",
-    "\n",
-    "1. **Tunable hyperparameters**: The names of hyperparameters that can be tuned, their default values, and the internal classes they are defined in.\n",
-    "1. **Available metrics**: The metrics that can be used to evaluate the performance of the model. One of these must be provided when running the tuner.\n",
-    "1. **Default search space**: The default search space for the model class, which will be used if no search space is provided by the user."
+    "`ModelTuner` will register all tunable hyperparameters in `SCVI` and all of them are accessible to tune starting version 1.2.0."
    ]
   },
   {
@@ -750,7 +746,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.12.4"
   },
   "vscode": {
    "interpreter": {
@@ -1232,13 +1228,13 @@
        "description": "",
        "description_allow_html": false,
        "layout": "IPY_MODEL_4a62519b71744f8b8fb9d362d3818644",
-       "max": 65714.0,
-       "min": 0.0,
+       "max": 65714,
+       "min": 0,
        "orientation": "horizontal",
        "style": "IPY_MODEL_8b21b549e9bf4f6ea1afac4cce08f2a2",
        "tabbable": null,
        "tooltip": null,
-       "value": 65714.0
+       "value": 65714
       }
      },
      "a2d3f19ade734df9819f1d9797327044": {


### PR DESCRIPTION
## Formatting

- [ ] My tutorial has only one top-level (`#`) header

## Reproducibility

- [ ] My tutorial works on Google Colab
- [ ] My tutorial sets `scvi.settings.seed = 0` at the beginning of the notebook
- [ ] My tutorial has been run and includes outputs (e.g. plots, tables)

## Other

- [ ] Counts and normalized data should co-exist in the datasets, see the [API overview](https://docs.scvi-tools.org/en/stable/tutorials/notebooks/api_overview.html) for an example
- [ ] For scRNA-seq data, normalization should be counts per median library size and then log1p transformed -- if not, a reason should be given
