### PR TITLE
Update run_notebook_macos.yaml

### DIFF
--- a/.github/workflows/run_notebook_macos.yaml
+++ b/.github/workflows/run_notebook_macos.yaml
@@ -1,4 +1,4 @@
-name: run notebook
+name: run notebook macos
 
 on:
   workflow_call:
@@ -27,19 +27,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Create Conda environment and install dependencies
-        run: |
-          conda init bash
-          source ~/.bash_profile
-          conda activate scvi
+      # - name: Create Conda environment and install dependencies
+      #   run: |
+      #     conda init bash
+      #     source ~/.bash_profile
+      #     conda activate scvi
 
-      - name: Install dependencies
+      # - name: Install dependencies
+      #   run: |
+      #     python -m pip install --upgrade pip wheel uv
+      #     python -m pip install "scvi-tools[tests]"
+      #     python -m pip install jax-metal
+      #     python -m ipykernel install
+
+      - name: Install Python kernel
         run: |
-          python -m pip install --upgrade pip wheel uv
-          python -m pip install "scvi-tools[tests]"
-          python -m pip install jax-metal
           python -m ipykernel install
-
+          
       - name: Run notebook
         run: |
           python -m jupyter nbconvert --execute --inplace ${{ inputs.notebook }}


### PR DESCRIPTION
## Formatting

- [ ] My tutorial has only one top-level (`#`) header

## Reproducibility

- [ ] My tutorial works on Google Colab
- [ ] My tutorial sets `scvi.settings.seed = 0` at the beginning of the notebook
- [ ] My tutorial has been run and includes outputs (e.g. plots, tables)

## Other

- [ ] Counts and normalized data should co-exist in the datasets, see the [API overview](https://docs.scvi-tools.org/en/stable/tutorials/notebooks/api_overview.html) for an example
- [ ] For scRNA-seq data, normalization should be counts per median library size and then log1p transformed -- if not, a reason should be given
