### PR TITLE
Update run_notebook_macos.yaml

### DIFF
--- a/.github/workflows/run_notebook_macos.yaml
+++ b/.github/workflows/run_notebook_macos.yaml
@@ -27,26 +27,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # - name: Create Conda environment and install dependencies
-      #   run: |
-      #     conda init bash
-      #     source ~/.bash_profile
-      #     conda activate scvi
+      - name: Create Conda environment and install dependencies
+        run: |
+          conda init bash
+          source ~/.bash_profile
+          conda activate scvi
 
       # - name: Install dependencies
       #   run: |
       #     python -m pip install --upgrade pip wheel uv
       #     python -m pip install "scvi-tools[tests]"
       #     python -m pip install jax-metal
-      #     python -m ipykernel install
 
-      - name: Install Python kernel
-        run: |
-          python -m ipykernel install
+      # - name: Install Python kernel
+      #   run: |
+      #     python -m ipykernel install --user
           
       - name: Run notebook
         run: |
-          python -m jupyter nbconvert --execute --inplace ${{ inputs.notebook }}
+          python -m jupyter nbconvert --execute --inplace ${{ inputs.notebook }} 
 
       - uses: peter-evans/create-pull-request@v5
         with:


### PR DESCRIPTION
## Formatting

- [ ] My tutorial has only one top-level (`#`) header

## Reproducibility

- [ ] My tutorial works on Google Colab
- [ ] My tutorial sets `scvi.settings.seed = 0` at the beginning of the notebook
- [ ] My tutorial has been run and includes outputs (e.g. plots, tables)

## Other

- [ ] Counts and normalized data should co-exist in the datasets, see the [API overview](https://docs.scvi-tools.org/en/stable/tutorials/notebooks/api_overview.html) for an example
- [ ] For scRNA-seq data, normalization should be counts per median library size and then log1p transformed -- if not, a reason should be given
