### PR TITLE
`api_overview`: `latent_subset` fix

### DIFF
--- a/quick_start/api_overview.ipynb
+++ b/quick_start/api_overview.ipynb
@@ -597,7 +597,7 @@
     {
      "data": {
       "text/plain": [
-       "(18641, 10)"
+       "(2446, 10)"
       ]
      },
      "execution_count": 16,
@@ -608,7 +608,7 @@
    "source": [
     "adata_subset = adata[adata.obs.cell_type == \"Fibroblast\"]\n",
     "latent_subset = model.get_latent_representation(adata_subset)\n",
-    "latent.shape"
+    "latent_subset.shape"
    ]
   },
   {


### PR DESCRIPTION
This cell seemed to be erroneously showing the same `latent.shape` value from the previous cell